### PR TITLE
comply with mirage3 changes

### DIFF
--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -51,21 +51,18 @@ type vif_info = {
 let devices = Hashtbl.create 1
 
 let connect devname =
-  try
-    Lwt_vmnet.init () >>= fun dev ->
-    let devname = "unknown" in (* TODO fix *)
-    let mac = Lwt_vmnet.mac dev in
-    let active = true in
-    let buf_sz = 4096 in (* TODO get from vmnet *)
-    let t = {
-      id=devname; dev; active; mac; buf_sz;
-      stats= { rx_bytes=0L;rx_pkts=0l;
-               tx_bytes=0L; tx_pkts=0l }; } in
-    Hashtbl.add devices devname t;
-    printf "Netif: connect %s\n%!" devname;
-    return (`Ok t)
-  with
-    exn -> return (`Error (`Unknown (Printexc.to_string exn)))
+  Lwt_vmnet.init () >>= fun dev ->
+  let devname = "unknown" in (* TODO fix *)
+  let mac = Lwt_vmnet.mac dev in
+  let active = true in
+  let buf_sz = 4096 in (* TODO get from vmnet *)
+  let t = {
+    id=devname; dev; active; mac; buf_sz;
+    stats= { rx_bytes=0L;rx_pkts=0l;
+             tx_bytes=0L; tx_pkts=0l }; } in
+  Hashtbl.add devices devname t;
+  printf "Netif: connect %s\n%!" devname;
+  return (`Ok t)
 
 let disconnect t =
   printf "Netif: disconnect %s\n%!" t.id;

--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -18,7 +18,6 @@ open Lwt
 open Printf
 
 type +'a io = 'a Lwt.t
-type id = string
 
 (** IO operation errors *)
 type error = [
@@ -35,7 +34,7 @@ type stats = {
 }
 
 type t = {
-  id: id;
+  id: string;
   buf_sz: int;
   mutable active: bool;
   mac: Macaddr.t;
@@ -44,7 +43,7 @@ type t = {
 }
 
 type vif_info = {
-  vif_id: id;
+  vif_id: string;
   vif_fd: Unix.file_descr;
 }
 
@@ -133,8 +132,6 @@ let writev t pages =
       ) pages;
     let v = Cstruct.sub page 0 !off in
     write t v
-
-let id t = t.id
 
 let mac t = t.mac
 

--- a/lib/netif.mli
+++ b/lib/netif.mli
@@ -18,6 +18,5 @@ include V1.NETWORK
 with type 'a io = 'a Lwt.t
 and type     page_aligned_buffer = Io_page.t
 and type     buffer = Cstruct.t
-and type     id = string
 and type     macaddr = Macaddr.t
 val connect : string -> t Lwt.t

--- a/lib/netif.mli
+++ b/lib/netif.mli
@@ -20,4 +20,4 @@ and type     page_aligned_buffer = Io_page.t
 and type     buffer = Cstruct.t
 and type     id = string
 and type     macaddr = Macaddr.t
-val connect : string -> [> `Ok of t | `Error of error ] Lwt.t
+val connect : string -> t Lwt.t


### PR DESCRIPTION
- Remove `id` type, which will not be required by `mirage-types` 3.
- `connect` should no longer return an `Ok | Error` variant but rather return the result directly.
