### PR TITLE
if something cancels `listen`, don't restart it

### DIFF
--- a/src/netif.ml
+++ b/src/netif.ml
@@ -88,7 +88,10 @@ let rec listen t fn =
                  Lwt.return_unit)
           );
           listen t fn
-      ) (function exn ->
+      ) (function
+        | Lwt.Canceled -> Log.info (fun l -> l "[netif-input] listen function canceled, terminating");
+          Lwt.return (Error `Disconnected)
+        | exn ->
         Log.err (fun l -> l "[netif-input] error : %s" (Printexc.to_string exn));
         listen t fn)
   | false ->


### PR DESCRIPTION
See also the workalike in https://github.com/mirage/mirage-net-unix/pull/36 .  This is especially important for mirage-net-macosx because of #3 -- without this fix, artifacts configured with `--dhcp true` will have roughly every other packet directed to the original canceled listener, which only knows how to handle DHCP transactions.

/cc @samoht 