### PR TITLE
adjust to upcoming mirage-net-2.0.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
+  - PACKAGE="mirage-net-macosx"
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
   matrix:
-  - OCAML_VERSION=4.04 PACKAGE=mirage-net-macosx
-  - OCAML_VERSION=4.06 PACKAGE=mirage-net-macosx
-  - OCAML_VERSION=4.07 PACKAGE=mirage-net-macosx
+  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.06
+  - OCAML_VERSION=4.07
 os:
   - osx

--- a/mirage-net-macosx.opam
+++ b/mirage-net-macosx.opam
@@ -20,9 +20,7 @@ depends: [
   "sexplib"
   "logs"
   "lwt" {>= "2.4.3"}
-  "mirage-net-lwt" {>= "1.0.0"}
-  "io-page" {>= "2.0.0"}
-  "io-page-unix" {>= "2.0.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
   "vmnet"
 ]
 tags: "org:mirage"

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,6 @@
 (library
  (name mirage_net_macosx)
  (public_name mirage-net-macosx)
- (libraries cstruct io-page io-page.unix macaddr lwt lwt.unix mirage-net-lwt
-   sexplib logs vmnet.lwt threads)
+ (libraries cstruct macaddr lwt lwt.unix mirage-net-lwt sexplib logs vmnet.lwt threads)
  (flags :standard -w A-4-41-44 -warn-error +1..49 -short-paths -safe-string)
  (wrapped false))


### PR DESCRIPTION
from apple's documentation, it is not entirely clear to me what the `iovec` passed to `Vmnet.write` should look like. atm, bigarrays (allocated via Io_page) with offset and length are used. in here, cstructs are used (i.e. not necessarily page-aligned).
another question I have is whether `Vmnet.maximum_packet_size` is the MTU or the maximum size of a single iovec -- i.e. can there be multiple of size = maximum_packet_size? is there another function in their vmnet API for finding out the MTU?

this superseeds #28 